### PR TITLE
deploy: запуск bsl-indexer в Docker (демон + read-only MCP HTTP)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Контекст сборки Docker — корень репозитория (deploy/docker/Dockerfile).
+# Отсекаем тяжёлые и ненужные для `cargo build` артефакты, чтобы контекст не
+# раздувался и не инвалидировал кэш слоёв.
+target/
+target2/
+.git/
+.github/
+.code-index/
+*.db
+*.db-shm
+*.db-wal
+.claude/
+.playwright-mcp/
+node_modules/
+npm/
+docs/
+deploy/docker/repos/

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,30 @@
+# bsl-indexer в контейнере: демон-писатель + read-only MCP HTTP serve.
+#
+# Контекст сборки — корень репозитория (см. deploy/docker/docker-compose.yml,
+# поле build.context). Исходники копируются из контекста, .dockerignore рядом с
+# ним отсекает target/ и .git, чтобы контекст не раздувался.
+#
+#   docker build -f deploy/docker/Dockerfile -t bsl-indexer:local .
+
+# ---- build ----
+# slim-база вдвое легче полного rust:bookworm (важно на медленной сети);
+# gcc нужен для bundled rusqlite/zstd (компиляция C). reqwest — rustls (без openssl).
+FROM rust:1-slim-bookworm AS build
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gcc \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+# bsl-indexer без feature enrichment (LLM-обогащение не нужно для индекса/serve).
+RUN cargo build --release -p bsl-indexer
+
+# ---- runtime ----
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/bsl-indexer /usr/local/bin/bsl-indexer
+COPY deploy/docker/entrypoint.sh /usr/local/bin/bsl-indexer-entrypoint.sh
+ENV CODE_INDEX_HOME=/data/code-index-home
+WORKDIR /data
+ENTRYPOINT ["bash", "/usr/local/bin/bsl-indexer-entrypoint.sh"]

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,85 @@
+# bsl-indexer в Docker
+
+Развёртывание `bsl-indexer` (структурный поиск по коду, MCP по HTTP) в одном
+контейнере: демон-писатель + read-only `serve`. Индексирует примонтированные
+репозитории и отдаёт MCP на `http://localhost:9003/mcp`.
+
+Альтернатива [systemd-деплою](../systemd/bsl-indexer-daemon.service) — когда
+удобнее контейнер (изоляция toolchain, воспроизводимая сборка), а не установка
+бинарника на хост.
+
+## Архитектура контейнера
+
+Один контейнер, два процесса (общий loopback и `$CODE_INDEX_HOME`):
+
+- **демон** (`bsl-indexer daemon run`) — единственный писатель: делает начальную
+  индексацию путей из `daemon.toml` и держит `<repo>/.code-index/index.db`
+  актуальным при изменениях; пишет свой рантайм-порт в `$CODE_INDEX_HOME/daemon.json`.
+- **serve** (`bsl-indexer serve --transport http`) — read-only MCP: отдаёт `/mcp`,
+  читает те же `index.db`. Находит демон через `daemon.json`.
+
+Оркестрация — [`entrypoint.sh`](entrypoint.sh) (очистка stale-состояния → демон в
+фоне → ожидание `daemon.json` → serve).
+
+### Почему entrypoint чистит `daemon.pid`/`daemon.json` при старте
+
+Демон защищён PID-файлом (`daemon.pid`) и снимает его RAII-очисткой при штатном
+завершении. Но при `SIGKILL` (например, `docker stop` по таймауту или падение)
+очистка не срабатывает — PID-файл остаётся на именованном томе. У нового
+контейнера **свежий PID-namespace**, где PID из прошлого инстанса (часто `8`)
+почти наверняка занят другим процессом; проверка живости даёт ложное «демон уже
+запущен» → демон падает → `restart: unless-stopped` → **краш-луп** (порт 9003 не
+слушается). В контейнере ни один прошлый демон дожить не может, поэтому entrypoint
+безусловно удаляет `daemon.pid`/`daemon.json` при старте — это разрывает цикл.
+
+## Запуск
+
+1. Отредактируйте [`daemon.toml`](daemon.toml) под свои репозитории (пути —
+   внутри контейнера, в `/repos`).
+2. Укажите каталог с репозиториями через `REPOS_DIR` (или `.env`) — он монтируется
+   в `/repos`:
+
+   ```bash
+   REPOS_DIR=/path/to/repos \
+     docker compose -f deploy/docker/docker-compose.yml up -d --build
+   ```
+
+   По умолчанию монтируется `deploy/docker/repos`.
+
+Первый билд компилирует Rust (~5–10 мин). Начальная индексация идёт в фоне уже
+после старта; пока индекс не готов, инструменты возвращают `{status, progress}`
+вместо ошибки.
+
+## Проверка
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml logs -f bsl-indexer   # логи
+docker compose -f deploy/docker/docker-compose.yml exec bsl-indexer \
+  bsl-indexer daemon status --json                                       # статус индексации
+curl -s http://localhost:9003/mcp -H 'Accept: text/event-stream'         # эндпоинт MCP
+```
+
+## Подключение к MCP-клиенту
+
+```json
+"code-index": { "type": "http", "url": "http://localhost:9003/mcp" }
+```
+
+## Файлы
+
+- [`Dockerfile`](Dockerfile) — multi-stage сборка (`rust:1-slim-bookworm` + gcc →
+  `debian:bookworm-slim`), бинарник `bsl-indexer` без feature `enrichment`.
+- [`docker-compose.yml`](docker-compose.yml) — сервис `bsl-indexer` (build
+  context = корень репо), том с репозиториями (`REPOS_DIR`), именованный том
+  `bsl-indexer-home`, порт `9003`.
+- [`entrypoint.sh`](entrypoint.sh) — очистка stale-состояния + демон + serve.
+- [`daemon.toml`](daemon.toml) — список индексируемых путей (правится под себя).
+- [`../../.dockerignore`](../../.dockerignore) — отсекает `target/`, `.git` и пр.
+  из контекста сборки.
+
+## Заметки
+
+- Порт `9003` задаётся `MCP_HTTP_PORT` (проброс в compose менять синхронно).
+- Feature `enrichment` (LLM-обогащение) не включён — для индекса/поиска не нужен.
+- Пересобрать после обновления исходников:
+  `docker compose -f deploy/docker/docker-compose.yml up -d --build`.

--- a/deploy/docker/daemon.toml
+++ b/deploy/docker/daemon.toml
@@ -1,0 +1,24 @@
+# Конфиг фонового демона bsl-indexer в контейнере.
+# Пути — ВНУТРИ контейнера (том с исходниками монтируется в /repos, см.
+# docker-compose.yml). Демон — единственный писатель: индексирует перечисленные
+# папки и держит <repo>/.code-index/index.db актуальным. serve (read-only MCP
+# HTTP) читает те же index.db.
+#
+# ОТРЕДАКТИРУЙТЕ [[paths]] под свои репозитории перед запуском.
+
+[daemon]
+http_host = "127.0.0.1"   # control-сервер демона (loopback внутри контейнера)
+http_port = 0             # автовыбор свободного порта; реальный пишется в daemon.json
+log_level = "info"
+
+# Пример: выгрузка конфигурации 1С (язык bsl). alias — короткое имя репо в MCP.
+[[paths]]
+path = "/repos/cf"
+alias = "cf"
+language = "bsl"
+
+# Пример второго репо (расширение). Добавляйте/удаляйте блоки по необходимости.
+# [[paths]]
+# path = "/repos/mcp_tools"
+# alias = "mcp_tools"
+# language = "bsl"

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+# bsl-indexer — MCP-сервер структурного поиска по коду в контейнере.
+#
+#   docker compose -f deploy/docker/docker-compose.yml up -d --build
+#
+# Собирает bsl-indexer из исходников репозитория, индексирует примонтированные
+# репозитории (см. daemon.toml) и отдаёт MCP по HTTP на http://localhost:9003/mcp.
+name: bsl-indexer
+
+services:
+  bsl-indexer:
+    build:
+      # Контекст — корень репозитория (исходники для cargo build).
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    image: bsl-indexer:local
+    container_name: bsl-indexer
+    environment:
+      CODE_INDEX_HOME: /data/code-index-home
+      MCP_HTTP_HOST: 0.0.0.0
+      MCP_HTTP_PORT: "9003"
+    volumes:
+      # Индексируемые репозитории (rw: демон пишет <repo>/.code-index/index.db
+      # рядом с исходниками). Переопределяется переменной REPOS_DIR (или .env).
+      - ${REPOS_DIR:-./repos}:/repos
+      # Runtime демона (daemon.json и пр.) — общий для демона и serve.
+      - bsl-indexer-home:/data/code-index-home
+      # Конфиг с путями индексации — из репозитория (host-config, правится под себя).
+      - ./daemon.toml:/data/code-index-home/daemon.toml:ro
+    ports:
+      - "9003:9003"
+    restart: unless-stopped
+
+volumes:
+  bsl-indexer-home:

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Запускает bsl-indexer в одном контейнере: демон (писатель) + serve (read-only
+# MCP HTTP). Оба процесса делят loopback и $CODE_INDEX_HOME — serve находит демон
+# через $CODE_INDEX_HOME/daemon.json (см. docs/bsl-indexer.md).
+set -euo pipefail
+
+: "${CODE_INDEX_HOME:=/data/code-index-home}"
+: "${MCP_HTTP_HOST:=0.0.0.0}"
+: "${MCP_HTTP_PORT:=9003}"
+export CODE_INDEX_HOME
+mkdir -p "$CODE_INDEX_HOME"
+
+if [[ ! -f "$CODE_INDEX_HOME/daemon.toml" ]]; then
+  echo "[bsl-indexer] ОШИБКА: нет $CODE_INDEX_HOME/daemon.toml (примонтируйте deploy/docker/daemon.toml)" >&2
+  exit 1
+fi
+
+# Свежий контейнер = новый PID-namespace: любые daemon.pid/daemon.json на томе
+# остались от прошлого (нечисто завершённого) инстанса — RAII-очистка PID-файла
+# не срабатывает при SIGKILL. Проверка живости PID внутри демона ненадёжна: PID
+# из прошлого контейнера (напр. 8) совпадает с живым процессом нового → ложное
+# «демон уже запущен» → краш-луп. В контейнере ни один прошлый демон дожить не
+# мог, поэтому runtime-состояние всегда безопасно удалить при старте.
+rm -f "$CODE_INDEX_HOME/daemon.pid" "$CODE_INDEX_HOME/daemon.json"
+
+echo "[bsl-indexer] запуск демона (писатель, начальная индексация)…"
+bsl-indexer daemon run &
+DAEMON_PID=$!
+
+# Ждём, пока демон запишет daemon.json (готов; индексация может ещё идти в фоне).
+echo "[bsl-indexer] ожидание готовности демона ($CODE_INDEX_HOME/daemon.json)…"
+for _ in $(seq 1 120); do
+  [[ -f "$CODE_INDEX_HOME/daemon.json" ]] && break
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "[bsl-indexer] демон завершился преждевременно" >&2
+    wait "$DAEMON_PID" || true
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "[bsl-indexer] запуск MCP HTTP serve на ${MCP_HTTP_HOST}:${MCP_HTTP_PORT} (/mcp)…"
+bsl-indexer serve --transport http --host "$MCP_HTTP_HOST" --port "${MCP_HTTP_PORT}" \
+  --config "$CODE_INDEX_HOME/daemon.toml" &
+SERVE_PID=$!
+
+# Если любой из процессов упадёт — гасим контейнер, restart policy перезапустит.
+wait -n "$DAEMON_PID" "$SERVE_PID"
+echo "[bsl-indexer] процесс завершился — останавливаю контейнер" >&2
+kill "$DAEMON_PID" "$SERVE_PID" 2>/dev/null || true
+exit 1


### PR DESCRIPTION
Контейнерная альтернатива systemd-деплою: один контейнер, два процесса (демон-писатель + serve) с общим CODE_INDEX_HOME. Индексирует примонтированные в /repos репозитории, отдаёт MCP по HTTP на :9003.

entrypoint.sh при старте безусловно чистит daemon.pid/daemon.json на томе: у нового контейнера свежий PID-namespace, где PID из прошлого (нечисто завершённого) инстанса совпадает с чужим живым процессом → проверка живости в демоне даёт ложное «демон уже запущен» → краш-луп (порт не слушается). В контейнере прошлый демон дожить не может, поэтому runtime-состояние безопасно удалять при старте.

- deploy/docker/Dockerfile — multi-stage (rust:1-slim-bookworm + gcc → debian:bookworm-slim), bsl-indexer без feature enrichment
- deploy/docker/docker-compose.yml — сервис bsl-indexer (context = корень репо), том репозиториев (REPOS_DIR), именованный том bsl-indexer-home, порт 9003
- deploy/docker/entrypoint.sh — очистка stale-состояния → демон → serve
- deploy/docker/daemon.toml — пример путей индексации (правится под себя)
- deploy/docker/README.md — сборка, запуск, проверка, подключение
- .dockerignore — отсекает target/, .git, docs/ и пр. из контекста сборки

Проверено : образ собирается; end-to-end MCP initialize отдаёт code-index-mcp 0.44.3, serve слушает /mcp, сессия создаётся.