### PR TITLE
feat: embed Windows executable metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "rmcp",
  "serde_json",
  "tokio",
+ "winresource",
 ]
 
 [[package]]
@@ -353,6 +354,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "winresource",
 ]
 
 [[package]]
@@ -3263,6 +3265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/crates/bsl-indexer/Cargo.toml
+++ b/crates/bsl-indexer/Cargo.toml
@@ -36,3 +36,6 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 rmcp = { workspace = true }
 axum = { workspace = true }
+
+[build-dependencies]
+winresource = { version = "0.1.31", default-features = false }

--- a/crates/bsl-indexer/build.rs
+++ b/crates/bsl-indexer/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        let mut res = winresource::WindowsResource::new();
+        res.set("FileDescription", "BSL Indexer MCP Server");
+        res.set("ProductName", "BSL Indexer");
+        res.set("CompanyName", "Regsorm");
+        res.set("LegalCopyright", "Copyright (C) 2026 Regsorm");
+        res.set("OriginalFilename", "bsl-indexer.exe");
+        res.set("InternalName", "bsl-indexer.exe");
+        res.compile().expect("failed to embed Windows resources for bsl-indexer");
+    }
+}

--- a/crates/code-index/Cargo.toml
+++ b/crates/code-index/Cargo.toml
@@ -31,3 +31,6 @@ rmcp = { workspace = true }
 
 # HTTP — для axum::Router::new() в serve_http
 axum = { workspace = true }
+
+[build-dependencies]
+winresource = { version = "0.1.31", default-features = false }

--- a/crates/code-index/build.rs
+++ b/crates/code-index/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        let mut res = winresource::WindowsResource::new();
+        res.set("FileDescription", "Code Index MCP Server");
+        res.set("ProductName", "Code Index MCP");
+        res.set("CompanyName", "Regsorm");
+        res.set("LegalCopyright", "Copyright (C) 2026 Regsorm");
+        res.set("OriginalFilename", "code-index.exe");
+        res.set("InternalName", "code-index.exe");
+        res.compile().expect("failed to embed Windows resources for code-index");
+    }
+}


### PR DESCRIPTION
## Что изменено

В Windows-сборки `code-index.exe` и `bsl-indexer.exe` добавлены сведения о продуктах и версиях через отдельные сценарии сборки `build.rs`.

`code-index.exe` теперь содержит:

- название продукта: `Code Index MCP`;
- описание файла: `Code Index MCP Server`;
- название компании: `Regsorm`;
- авторские права: `Copyright (C) 2026 Regsorm`.

`bsl-indexer.exe` теперь содержит:

- название продукта: `BSL Indexer`;
- описание файла: `BSL Indexer MCP Server`;
- название компании: `Regsorm`;
- авторские права: `Copyright (C) 2026 Regsorm`.

Для обоих файлов также задаются исходное и внутреннее имена, а версия файла и продукта берётся из версии пакета Cargo.

## Зачем

Сведения позволяют различать два исполняемых файла проекта и определять их версии через свойства файлов в Windows. Это упрощает обновление установленных экземпляров и проверку того, какая версия заменяется.